### PR TITLE
feat: add repositories

### DIFF
--- a/src/main/java/gorbiel/stock_sim/audit/repository/AuditLogEntryRepository.java
+++ b/src/main/java/gorbiel/stock_sim/audit/repository/AuditLogEntryRepository.java
@@ -1,0 +1,10 @@
+package gorbiel.stock_sim.audit.repository;
+
+import gorbiel.stock_sim.audit.model.AuditLogEntry;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuditLogEntryRepository extends JpaRepository<AuditLogEntry, Long> {
+
+    List<AuditLogEntry> findAllByOrderByIdAsc();
+}

--- a/src/main/java/gorbiel/stock_sim/bank/repository/BankStockHoldingRepository.java
+++ b/src/main/java/gorbiel/stock_sim/bank/repository/BankStockHoldingRepository.java
@@ -1,0 +1,6 @@
+package gorbiel.stock_sim.bank.repository;
+
+import gorbiel.stock_sim.bank.model.BankStockHolding;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BankStockHoldingRepository extends JpaRepository<BankStockHolding, String> {}

--- a/src/main/java/gorbiel/stock_sim/wallet/repository/WalletRepository.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/repository/WalletRepository.java
@@ -1,0 +1,6 @@
+package gorbiel.stock_sim.wallet.repository;
+
+import gorbiel.stock_sim.wallet.model.Wallet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WalletRepository extends JpaRepository<Wallet, String> {}

--- a/src/main/java/gorbiel/stock_sim/wallet/repository/WalletStockHoldingRepository.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/repository/WalletStockHoldingRepository.java
@@ -1,0 +1,10 @@
+package gorbiel.stock_sim.wallet.repository;
+
+import gorbiel.stock_sim.wallet.model.WalletStockHolding;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WalletStockHoldingRepository extends JpaRepository<WalletStockHolding, Long> {
+
+    Optional<WalletStockHolding> findByWalletIdAndStockName(String walletId, String stockName);
+}


### PR DESCRIPTION
## Description

Create repository interfaces for core persistence models:
- Wallet
- Wallet stock holding
- Bank stock holding
- Audit log entry

Repositories extend `JpaRepository` and provide basic CRUD operations. Added minimal query methods required for upcoming service logic (e.g. lookup by wallet and stock, ordered audit log retrieval).

Persistence behavior will be verified in dedicated repository tests in a separate issue.

## Checklist
- [x] Code builds (`mvn clean install`)
- [ ] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)