### PR TITLE
feat: add persistence tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
+      <version>42.7.11</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -77,6 +78,11 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/gorbiel/stock_sim/persistence/CoreRepositoryTest.java
+++ b/src/test/java/gorbiel/stock_sim/persistence/CoreRepositoryTest.java
@@ -1,0 +1,95 @@
+package gorbiel.stock_sim.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import gorbiel.stock_sim.audit.model.AuditLogEntry;
+import gorbiel.stock_sim.audit.model.OperationType;
+import gorbiel.stock_sim.audit.repository.AuditLogEntryRepository;
+import gorbiel.stock_sim.bank.model.BankStockHolding;
+import gorbiel.stock_sim.bank.repository.BankStockHoldingRepository;
+import gorbiel.stock_sim.wallet.model.Wallet;
+import gorbiel.stock_sim.wallet.model.WalletStockHolding;
+import gorbiel.stock_sim.wallet.repository.WalletRepository;
+import gorbiel.stock_sim.wallet.repository.WalletStockHoldingRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@DataJpaTest
+class CoreRepositoryTest {
+
+    @Autowired
+    private WalletRepository walletRepository;
+
+    @Autowired
+    private WalletStockHoldingRepository walletStockHoldingRepository;
+
+    @Autowired
+    private BankStockHoldingRepository bankStockHoldingRepository;
+
+    @Autowired
+    private AuditLogEntryRepository auditLogEntryRepository;
+
+    @Test
+    void shouldSaveAndLoadWalletStockHolding() {
+        Wallet wallet = walletRepository.save(new Wallet("wallet-1"));
+        walletStockHoldingRepository.save(new WalletStockHolding(wallet, "AAPL", 3));
+
+        WalletStockHolding result = walletStockHoldingRepository
+                .findByWalletIdAndStockName("wallet-1", "AAPL")
+                .orElseThrow();
+
+        assertThat(result.getWallet().getId()).isEqualTo("wallet-1");
+        assertThat(result.getStockName()).isEqualTo("AAPL");
+        assertThat(result.getQuantity()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldSaveAndLoadBankStockHolding() {
+        bankStockHoldingRepository.save(new BankStockHolding("AAPL", 10));
+
+        BankStockHolding result = bankStockHoldingRepository.findById("AAPL").orElseThrow();
+
+        assertThat(result.getStockName()).isEqualTo("AAPL");
+        assertThat(result.getQuantity()).isEqualTo(10);
+    }
+
+    @Test
+    void shouldSaveAuditLogEntriesInOrder() {
+        auditLogEntryRepository.save(new AuditLogEntry(OperationType.BUY, "wallet-1", "AAPL"));
+        auditLogEntryRepository.save(new AuditLogEntry(OperationType.SELL, "wallet-1", "AAPL"));
+
+        var result = auditLogEntryRepository.findAllByOrderByIdAsc();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getType()).isEqualTo(OperationType.BUY);
+        assertThat(result.get(1).getType()).isEqualTo(OperationType.SELL);
+    }
+
+    @Test
+    void shouldRejectDuplicateWalletStockHolding() {
+        Wallet wallet = walletRepository.save(new Wallet("wallet-1"));
+
+        walletStockHoldingRepository.save(new WalletStockHolding(wallet, "AAPL", 1));
+        walletStockHoldingRepository.flush();
+
+        assertThatThrownBy(() -> walletStockHoldingRepository.saveAndFlush(new WalletStockHolding(wallet, "AAPL", 2)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void shouldRejectNegativeBankStockQuantity() {
+        assertThatThrownBy(() -> bankStockHoldingRepository.saveAndFlush(new BankStockHolding("AAPL", -1)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldRejectNegativeWalletStockQuantity() {
+        Wallet wallet = walletRepository.save(new Wallet("wallet-1"));
+
+        assertThatThrownBy(() -> new WalletStockHolding(wallet, "AAPL", -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## Description

Add repository tests for the core persistence model.

Covered:
- saving and loading wallet stock holdings
- saving and loading bank stock holdings
- saving audit log entries in insertion order
- enforcing duplicate wallet-stock constraints
- protecting against negative stock quantities

## How to test
Steps to verify:
Verified with `./mvnw clean verify`.

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)