### PR TITLE
20 api implement post stocks endpoint

### DIFF
--- a/src/main/java/gorbiel/stock_sim/bank/controller/BankStockController.java
+++ b/src/main/java/gorbiel/stock_sim/bank/controller/BankStockController.java
@@ -1,0 +1,23 @@
+package gorbiel.stock_sim.bank.controller;
+
+import gorbiel.stock_sim.bank.dto.UpdateBankStocksRequest;
+import gorbiel.stock_sim.bank.service.BankStockService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BankStockController {
+
+    private final BankStockService bankStockService;
+
+    @PostMapping("/stocks")
+    public ResponseEntity<Void> updateBankStocks(@Valid @RequestBody UpdateBankStocksRequest request) {
+        bankStockService.updateBankStocks(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/gorbiel/stock_sim/bank/dto/BankStockItemRequest.java
+++ b/src/main/java/gorbiel/stock_sim/bank/dto/BankStockItemRequest.java
@@ -1,0 +1,6 @@
+package gorbiel.stock_sim.bank.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record BankStockItemRequest(@NotBlank String name, @Min(0) int quantity) {}

--- a/src/main/java/gorbiel/stock_sim/bank/dto/UpdateBankStocksRequest.java
+++ b/src/main/java/gorbiel/stock_sim/bank/dto/UpdateBankStocksRequest.java
@@ -1,0 +1,7 @@
+package gorbiel.stock_sim.bank.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record UpdateBankStocksRequest(@NotNull List<@Valid BankStockItemRequest> stocks) {}

--- a/src/main/java/gorbiel/stock_sim/bank/service/BankStockService.java
+++ b/src/main/java/gorbiel/stock_sim/bank/service/BankStockService.java
@@ -1,0 +1,8 @@
+package gorbiel.stock_sim.bank.service;
+
+import gorbiel.stock_sim.bank.dto.UpdateBankStocksRequest;
+
+public interface BankStockService {
+
+    void updateBankStocks(UpdateBankStocksRequest request);
+}

--- a/src/main/java/gorbiel/stock_sim/bank/service/BankStockServiceImpl.java
+++ b/src/main/java/gorbiel/stock_sim/bank/service/BankStockServiceImpl.java
@@ -1,0 +1,32 @@
+package gorbiel.stock_sim.bank.service;
+
+import gorbiel.stock_sim.bank.dto.BankStockItemRequest;
+import gorbiel.stock_sim.bank.dto.UpdateBankStocksRequest;
+import gorbiel.stock_sim.bank.model.BankStockHolding;
+import gorbiel.stock_sim.bank.repository.BankStockHoldingRepository;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BankStockServiceImpl implements BankStockService {
+
+    private final BankStockHoldingRepository bankStockHoldingRepository;
+
+    @Override
+    @Transactional
+    public void updateBankStocks(UpdateBankStocksRequest request) {
+        bankStockHoldingRepository.deleteAll();
+
+        List<BankStockHolding> holdings =
+                request.stocks().stream().map(this::toBankStockHolding).toList();
+
+        bankStockHoldingRepository.saveAll(holdings);
+    }
+
+    private BankStockHolding toBankStockHolding(BankStockItemRequest request) {
+        return new BankStockHolding(request.name(), request.quantity());
+    }
+}


### PR DESCRIPTION
## Description

Implement `POST /stocks` endpoint for managing bank stock state.

The endpoint:
- accepts a list of stock name/quantity pairs
- replaces the entire bank stock state
- validates input (non-null, non-negative quantities)
- returns `200 OK` on success


The implementation aligns with the domain model and will be covered by API tests in a later step.

## Changes

Introduced:
- request DTOs for API contract
- service layer handling full state replacement
- controller exposing the endpoint

## How to test
Steps to verify: mvn clean test

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)