### PR TITLE
feat: add GET endpoint for Bank Stocks

### DIFF
--- a/src/main/java/gorbiel/stock_sim/bank/controller/BankStockController.java
+++ b/src/main/java/gorbiel/stock_sim/bank/controller/BankStockController.java
@@ -1,10 +1,12 @@
 package gorbiel.stock_sim.bank.controller;
 
+import gorbiel.stock_sim.bank.dto.BankStocksResponse;
 import gorbiel.stock_sim.bank.dto.UpdateBankStocksRequest;
 import gorbiel.stock_sim.bank.service.BankStockService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,5 +21,10 @@ public class BankStockController {
     public ResponseEntity<Void> updateBankStocks(@Valid @RequestBody UpdateBankStocksRequest request) {
         bankStockService.updateBankStocks(request);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/stocks")
+    public ResponseEntity<BankStocksResponse> getBankStocks() {
+        return ResponseEntity.ok(bankStockService.getBankStocks());
     }
 }

--- a/src/main/java/gorbiel/stock_sim/bank/dto/BankStockItemResponse.java
+++ b/src/main/java/gorbiel/stock_sim/bank/dto/BankStockItemResponse.java
@@ -1,0 +1,3 @@
+package gorbiel.stock_sim.bank.dto;
+
+public record BankStockItemResponse(String name, int quantity) {}

--- a/src/main/java/gorbiel/stock_sim/bank/dto/BankStocksResponse.java
+++ b/src/main/java/gorbiel/stock_sim/bank/dto/BankStocksResponse.java
@@ -1,0 +1,5 @@
+package gorbiel.stock_sim.bank.dto;
+
+import java.util.List;
+
+public record BankStocksResponse(List<BankStockItemResponse> stocks) {}

--- a/src/main/java/gorbiel/stock_sim/bank/service/BankStockService.java
+++ b/src/main/java/gorbiel/stock_sim/bank/service/BankStockService.java
@@ -1,8 +1,11 @@
 package gorbiel.stock_sim.bank.service;
 
+import gorbiel.stock_sim.bank.dto.BankStocksResponse;
 import gorbiel.stock_sim.bank.dto.UpdateBankStocksRequest;
 
 public interface BankStockService {
 
     void updateBankStocks(UpdateBankStocksRequest request);
+
+    BankStocksResponse getBankStocks();
 }

--- a/src/main/java/gorbiel/stock_sim/bank/service/BankStockServiceImpl.java
+++ b/src/main/java/gorbiel/stock_sim/bank/service/BankStockServiceImpl.java
@@ -1,6 +1,8 @@
 package gorbiel.stock_sim.bank.service;
 
 import gorbiel.stock_sim.bank.dto.BankStockItemRequest;
+import gorbiel.stock_sim.bank.dto.BankStockItemResponse;
+import gorbiel.stock_sim.bank.dto.BankStocksResponse;
 import gorbiel.stock_sim.bank.dto.UpdateBankStocksRequest;
 import gorbiel.stock_sim.bank.model.BankStockHolding;
 import gorbiel.stock_sim.bank.repository.BankStockHoldingRepository;
@@ -24,6 +26,13 @@ public class BankStockServiceImpl implements BankStockService {
                 request.stocks().stream().map(this::toBankStockHolding).toList();
 
         bankStockHoldingRepository.saveAll(holdings);
+    }
+
+    @Override
+    public BankStocksResponse getBankStocks() {
+        return new BankStocksResponse(bankStockHoldingRepository.findAll().stream()
+                .map(h -> new BankStockItemResponse(h.getStockName(), h.getQuantity()))
+                .toList());
     }
 
     private BankStockHolding toBankStockHolding(BankStockItemRequest request) {


### PR DESCRIPTION
## Description

Implement `GET /stocks` endpoint to retrieve current bank stock state.

The endpoint:
- returns all stocks available in the bank
- exposes a response DTO with stock name and quantity
- reflects the current persisted state

Complements the POST endpoint and completes basic bank stock API.

## How to test
Steps to verify: `mvn clean test`

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)