### PR TITLE
feat: Add bank stock existence validation

### DIFF
--- a/src/main/java/gorbiel/stock_sim/bank/service/BankStockService.java
+++ b/src/main/java/gorbiel/stock_sim/bank/service/BankStockService.java
@@ -2,10 +2,13 @@ package gorbiel.stock_sim.bank.service;
 
 import gorbiel.stock_sim.bank.dto.BankStocksResponse;
 import gorbiel.stock_sim.bank.dto.UpdateBankStocksRequest;
+import gorbiel.stock_sim.bank.model.BankStockHolding;
 
 public interface BankStockService {
 
     void updateBankStocks(UpdateBankStocksRequest request);
 
     BankStocksResponse getBankStocks();
+
+    BankStockHolding getExistingStock(String stockName);
 }

--- a/src/main/java/gorbiel/stock_sim/bank/service/BankStockServiceImpl.java
+++ b/src/main/java/gorbiel/stock_sim/bank/service/BankStockServiceImpl.java
@@ -6,6 +6,7 @@ import gorbiel.stock_sim.bank.dto.BankStocksResponse;
 import gorbiel.stock_sim.bank.dto.UpdateBankStocksRequest;
 import gorbiel.stock_sim.bank.model.BankStockHolding;
 import gorbiel.stock_sim.bank.repository.BankStockHoldingRepository;
+import gorbiel.stock_sim.exception.ResourceNotFoundException;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,13 @@ public class BankStockServiceImpl implements BankStockService {
         return new BankStocksResponse(bankStockHoldingRepository.findAll().stream()
                 .map(h -> new BankStockItemResponse(h.getStockName(), h.getQuantity()))
                 .toList());
+    }
+
+    @Override
+    public BankStockHolding getExistingStock(String stockName) {
+        return bankStockHoldingRepository
+                .findById(stockName)
+                .orElseThrow(() -> new ResourceNotFoundException("Stock not found: " + stockName));
     }
 
     private BankStockHolding toBankStockHolding(BankStockItemRequest request) {

--- a/src/main/java/gorbiel/stock_sim/exception/ResourceNotFoundException.java
+++ b/src/main/java/gorbiel/stock_sim/exception/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package gorbiel.stock_sim.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/gorbiel/stock_sim/bank/service/BankStockServiceImplTest.java
+++ b/src/test/java/gorbiel/stock_sim/bank/service/BankStockServiceImplTest.java
@@ -1,0 +1,44 @@
+package gorbiel.stock_sim.bank.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import gorbiel.stock_sim.bank.model.BankStockHolding;
+import gorbiel.stock_sim.bank.repository.BankStockHoldingRepository;
+import gorbiel.stock_sim.exception.ResourceNotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BankStockServiceImplTest {
+
+    @Mock
+    private BankStockHoldingRepository bankStockHoldingRepository;
+
+    @InjectMocks
+    private BankStockServiceImpl bankStockService;
+
+    @Test
+    void shouldReturnExistingStock() {
+        BankStockHolding holding = new BankStockHolding("AAPL", 10);
+        when(bankStockHoldingRepository.findById("AAPL")).thenReturn(Optional.of(holding));
+
+        BankStockHolding result = bankStockService.getExistingStock("AAPL");
+
+        assertThat(result).isEqualTo(holding);
+    }
+
+    @Test
+    void shouldThrowWhenStockDoesNotExist() {
+        when(bankStockHoldingRepository.findById("UNKNOWN")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> bankStockService.getExistingStock("UNKNOWN"))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Stock not found: UNKNOWN");
+    }
+}


### PR DESCRIPTION
## Description

Add bank stock existence validation for future wallet operations.

This prepares wallet buy/sell operations to consistently return `404` for unknown stock names, while leaving zero-quantity handling to the buy operation logic.

## Changes

-Introduced a reusable service method that resolves existing bank stock holdings by stock name and throws `ResourceNotFoundException` when the stock does not exist.

## How to test
Steps to verify: `mvn clean test`

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)