### PR TITLE
22 task add tests for bank stock endpoints

### DIFF
--- a/src/test/java/gorbiel/stock_sim/bank/controller/BankStockControllerTest.java
+++ b/src/test/java/gorbiel/stock_sim/bank/controller/BankStockControllerTest.java
@@ -1,0 +1,130 @@
+package gorbiel.stock_sim.bank.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import gorbiel.stock_sim.bank.repository.BankStockHoldingRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class BankStockControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private BankStockHoldingRepository bankStockHoldingRepository;
+
+    @BeforeEach
+    void setUp() {
+        bankStockHoldingRepository.deleteAll();
+    }
+
+    @Test
+    void shouldReturnBankStocks() throws Exception {
+        mockMvc.perform(
+                        post("/stocks")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                {
+                                  "stocks": [
+                                    { "name": "stock1", "quantity": 99 },
+                                    { "name": "stock2", "quantity": 1 }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/stocks"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.stocks", hasSize(2)))
+                .andExpect(jsonPath("$.stocks[0].name").exists())
+                .andExpect(jsonPath("$.stocks[0].quantity").exists());
+    }
+
+    @Test
+    void shouldSetBankStockState() throws Exception {
+        mockMvc.perform(
+                        post("/stocks")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                {
+                                  "stocks": [
+                                    { "name": "stock1", "quantity": 99 }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/stocks"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.stocks", hasSize(1)))
+                .andExpect(jsonPath("$.stocks[0].name").value("stock1"))
+                .andExpect(jsonPath("$.stocks[0].quantity").value(99));
+    }
+
+    @Test
+    void shouldReplacePreviousBankStockState() throws Exception {
+        mockMvc.perform(
+                        post("/stocks")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                {
+                                  "stocks": [
+                                    { "name": "stock1", "quantity": 99 }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(
+                        post("/stocks")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                {
+                                  "stocks": [
+                                    { "name": "stock2", "quantity": 1 }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/stocks"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.stocks", hasSize(1)))
+                .andExpect(jsonPath("$.stocks[0].name").value("stock2"))
+                .andExpect(jsonPath("$.stocks[0].quantity").value(1));
+    }
+
+    @Test
+    void shouldRejectNegativeQuantity() throws Exception {
+        mockMvc.perform(
+                        post("/stocks")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        """
+                                {
+                                  "stocks": [
+                                    { "name": "stock1", "quantity": -1 }
+                                  ]
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/gorbiel/stock_sim/persistence/CoreRepositoryTest.java
+++ b/src/test/java/gorbiel/stock_sim/persistence/CoreRepositoryTest.java
@@ -16,8 +16,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
+@ActiveProfiles("test")
 class CoreRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
## Description

Add API tests for bank stock endpoints.

Covered:
- `GET /stocks` returns expected response structure
- `POST /stocks` sets bank stock state
- `POST /stocks` replaces previous state
- invalid negative quantities return `400 Bad Request`

Tests verify the endpoint contracts through MockMvc using the application context.

## How to test
Steps to verify: `mvn clean test`

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)