### PR TITLE
feat: Add wallet stock operation dto

### DIFF
--- a/src/main/java/gorbiel/stock_sim/audit/model/OperationType.java
+++ b/src/main/java/gorbiel/stock_sim/audit/model/OperationType.java
@@ -1,6 +1,29 @@
 package gorbiel.stock_sim.audit.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+
 public enum OperationType {
-    BUY,
-    SELL
+    BUY("buy"),
+    SELL("sell");
+
+    private final String value;
+
+    OperationType(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static OperationType fromValue(String value) {
+        return Arrays.stream(values())
+                .filter(type -> type.value.equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unsupported operation type: " + value));
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
 }

--- a/src/main/java/gorbiel/stock_sim/wallet/dto/WalletStockOperationRequest.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/dto/WalletStockOperationRequest.java
@@ -1,0 +1,6 @@
+package gorbiel.stock_sim.wallet.dto;
+
+import gorbiel.stock_sim.audit.model.OperationType;
+import jakarta.validation.constraints.NotNull;
+
+public record WalletStockOperationRequest(@NotNull OperationType type) {}


### PR DESCRIPTION
## Description

Define request contract for wallet stock operations.

## Changes

- Added request DTO for `POST /wallets/{wallet_id}/stocks/{stock_name}` with operation type handling for supported values:
  - `buy`
  - `sell`
- Updated operation type JSON mapping so API payloads use lowercase values while internal code continues to use enum constants.

## How to test
Steps to verify: `mvn clean test`

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)