### PR TITLE
feat: Add stock buy operation endpoint

### DIFF
--- a/src/main/java/gorbiel/stock_sim/exception/BadRequestException.java
+++ b/src/main/java/gorbiel/stock_sim/exception/BadRequestException.java
@@ -3,10 +3,10 @@ package gorbiel.stock_sim.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ResponseStatus(HttpStatus.NOT_FOUND)
-public class ResourceNotFoundException extends RuntimeException {
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
 
-    public ResourceNotFoundException(String message) {
+    public BadRequestException(String message) {
         super(message);
     }
 }

--- a/src/main/java/gorbiel/stock_sim/wallet/controller/WalletStockOperationController.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/controller/WalletStockOperationController.java
@@ -1,0 +1,24 @@
+package gorbiel.stock_sim.wallet.controller;
+
+import gorbiel.stock_sim.wallet.dto.WalletStockOperationRequest;
+import gorbiel.stock_sim.wallet.service.WalletStockOperationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class WalletStockOperationController {
+
+    private final WalletStockOperationService walletStockOperationService;
+
+    @PostMapping("/wallets/{walletId}/stocks/{stockName}")
+    public ResponseEntity<Void> processOperation(
+            @PathVariable String walletId,
+            @PathVariable String stockName,
+            @Valid @RequestBody WalletStockOperationRequest request) {
+        walletStockOperationService.processOperation(walletId, stockName, request.type());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/gorbiel/stock_sim/wallet/service/WalletStockOperationService.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/service/WalletStockOperationService.java
@@ -1,0 +1,8 @@
+package gorbiel.stock_sim.wallet.service;
+
+import gorbiel.stock_sim.audit.model.OperationType;
+
+public interface WalletStockOperationService {
+
+    void processOperation(String walletId, String stockName, OperationType type);
+}

--- a/src/main/java/gorbiel/stock_sim/wallet/service/WalletStockOperationServiceImpl.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/service/WalletStockOperationServiceImpl.java
@@ -1,0 +1,56 @@
+package gorbiel.stock_sim.wallet.service;
+
+import gorbiel.stock_sim.audit.model.AuditLogEntry;
+import gorbiel.stock_sim.audit.model.OperationType;
+import gorbiel.stock_sim.audit.repository.AuditLogEntryRepository;
+import gorbiel.stock_sim.bank.model.BankStockHolding;
+import gorbiel.stock_sim.bank.service.BankStockService;
+import gorbiel.stock_sim.exception.BadRequestException;
+import gorbiel.stock_sim.wallet.model.Wallet;
+import gorbiel.stock_sim.wallet.model.WalletStockHolding;
+import gorbiel.stock_sim.wallet.repository.WalletRepository;
+import gorbiel.stock_sim.wallet.repository.WalletStockHoldingRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WalletStockOperationServiceImpl implements WalletStockOperationService {
+
+    private final BankStockService bankStockService;
+    private final WalletRepository walletRepository;
+    private final WalletStockHoldingRepository walletStockHoldingRepository;
+    private final AuditLogEntryRepository auditLogEntryRepository;
+
+    @Override
+    @Transactional
+    public void processOperation(String walletId, String stockName, OperationType type) {
+        if (type != OperationType.BUY) {
+            throw new BadRequestException("Unsupported operation type for this endpoint implementation");
+        }
+
+        buyStock(walletId, stockName);
+    }
+
+    private void buyStock(String walletId, String stockName) {
+        BankStockHolding bankStock = bankStockService.getExistingStock(stockName);
+
+        if (bankStock.getQuantity() == 0) {
+            throw new BadRequestException("Stock is not available in bank: " + stockName);
+        }
+
+        Wallet wallet =
+                walletRepository.findById(walletId).orElseGet(() -> walletRepository.save(new Wallet(walletId)));
+
+        WalletStockHolding walletStock = walletStockHoldingRepository
+                .findByWalletIdAndStockName(walletId, stockName)
+                .orElseGet(() -> new WalletStockHolding(wallet, stockName, 0));
+
+        bankStock.decrease();
+        walletStock.increase();
+
+        walletStockHoldingRepository.save(walletStock);
+        auditLogEntryRepository.save(new AuditLogEntry(OperationType.BUY, walletId, stockName));
+    }
+}


### PR DESCRIPTION
## Description

Implement buy stock operation for wallet stock endpoint.

The operation:
- creates the wallet if it does not exist
- validates that the stock exists in the bank
- returns 404 for unknown stock names
- returns 400 when the bank has zero quantity
- decreases bank stock quantity by 1
- increases wallet stock quantity by 1
- records successful buy operations in the audit log

The task specifies single-stock operations only, so each buy operation transfers exactly one stock.

## How to test
Steps to verify: `mvn clean test`

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)