### PR TITLE
feat: Add stock sell operation endpoint

### DIFF
--- a/src/main/java/gorbiel/stock_sim/wallet/service/WalletStockOperationServiceImpl.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/service/WalletStockOperationServiceImpl.java
@@ -26,11 +26,10 @@ public class WalletStockOperationServiceImpl implements WalletStockOperationServ
     @Override
     @Transactional
     public void processOperation(String walletId, String stockName, OperationType type) {
-        if (type != OperationType.BUY) {
-            throw new BadRequestException("Unsupported operation type for this endpoint implementation");
+        switch (type) {
+            case BUY -> buyStock(walletId, stockName);
+            case SELL -> sellStock(walletId, stockName);
         }
-
-        buyStock(walletId, stockName);
     }
 
     private void buyStock(String walletId, String stockName) {
@@ -52,5 +51,26 @@ public class WalletStockOperationServiceImpl implements WalletStockOperationServ
 
         walletStockHoldingRepository.save(walletStock);
         auditLogEntryRepository.save(new AuditLogEntry(OperationType.BUY, walletId, stockName));
+    }
+
+    private void sellStock(String walletId, String stockName) {
+        BankStockHolding bankStock = bankStockService.getExistingStock(stockName);
+
+        Wallet wallet =
+                walletRepository.findById(walletId).orElseGet(() -> walletRepository.save(new Wallet(walletId)));
+
+        WalletStockHolding walletStock = walletStockHoldingRepository
+                .findByWalletIdAndStockName(walletId, stockName)
+                .orElseGet(() -> new WalletStockHolding(wallet, stockName, 0));
+
+        if (walletStock.getQuantity() == 0) {
+            throw new BadRequestException("Stock is not available in wallet: " + stockName);
+        }
+
+        walletStock.decrease();
+        bankStock.increase();
+
+        walletStockHoldingRepository.save(walletStock);
+        auditLogEntryRepository.save(new AuditLogEntry(OperationType.SELL, walletId, stockName));
     }
 }


### PR DESCRIPTION
## Description

Implement sell stock operation for wallet stock endpoint.

The operation:
- creates the wallet if it does not exist
- validates that the stock exists in the bank
- returns 404 for unknown stock names
- returns 400 when the wallet has zero quantity
- decreases wallet stock quantity by 1
- increases bank stock quantity by 1
- records successful sell operations in the audit log

Each sell operation transfers exactly one stock, as required by the task.

## How to test
Steps to verify: `mvn clean test`

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)