### PR TITLE
feat: Add wallet stock GET endpoint

### DIFF
--- a/src/main/java/gorbiel/stock_sim/wallet/controller/WalletController.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/controller/WalletController.java
@@ -1,6 +1,8 @@
 package gorbiel.stock_sim.wallet.controller;
 
+import gorbiel.stock_sim.wallet.dto.WalletResponse;
 import gorbiel.stock_sim.wallet.dto.WalletStockOperationRequest;
+import gorbiel.stock_sim.wallet.service.WalletQueryService;
 import gorbiel.stock_sim.wallet.service.WalletStockOperationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -9,9 +11,10 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-public class WalletStockOperationController {
+public class WalletController {
 
     private final WalletStockOperationService walletStockOperationService;
+    private final WalletQueryService walletQueryService;
 
     @PostMapping("/wallets/{walletId}/stocks/{stockName}")
     public ResponseEntity<Void> processOperation(
@@ -20,5 +23,10 @@ public class WalletStockOperationController {
             @Valid @RequestBody WalletStockOperationRequest request) {
         walletStockOperationService.processOperation(walletId, stockName, request.type());
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/wallets/{walletId}")
+    public ResponseEntity<WalletResponse> getWallet(@PathVariable String walletId) {
+        return ResponseEntity.ok(walletQueryService.getWallet(walletId));
     }
 }

--- a/src/main/java/gorbiel/stock_sim/wallet/dto/WalletResponse.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/dto/WalletResponse.java
@@ -1,0 +1,5 @@
+package gorbiel.stock_sim.wallet.dto;
+
+import java.util.List;
+
+public record WalletResponse(String id, List<WalletStockResponse> stocks) {}

--- a/src/main/java/gorbiel/stock_sim/wallet/dto/WalletStockResponse.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/dto/WalletStockResponse.java
@@ -1,0 +1,3 @@
+package gorbiel.stock_sim.wallet.dto;
+
+public record WalletStockResponse(String name, int quantity) {}

--- a/src/main/java/gorbiel/stock_sim/wallet/repository/WalletStockHoldingRepository.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/repository/WalletStockHoldingRepository.java
@@ -1,10 +1,13 @@
 package gorbiel.stock_sim.wallet.repository;
 
 import gorbiel.stock_sim.wallet.model.WalletStockHolding;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WalletStockHoldingRepository extends JpaRepository<WalletStockHolding, Long> {
 
     Optional<WalletStockHolding> findByWalletIdAndStockName(String walletId, String stockName);
+
+    List<WalletStockHolding> findAllByWalletId(String walletId);
 }

--- a/src/main/java/gorbiel/stock_sim/wallet/service/WalletQueryService.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/service/WalletQueryService.java
@@ -1,0 +1,8 @@
+package gorbiel.stock_sim.wallet.service;
+
+import gorbiel.stock_sim.wallet.dto.WalletResponse;
+
+public interface WalletQueryService {
+
+    WalletResponse getWallet(String walletId);
+}

--- a/src/main/java/gorbiel/stock_sim/wallet/service/WalletQueryServiceImpl.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/service/WalletQueryServiceImpl.java
@@ -1,0 +1,24 @@
+package gorbiel.stock_sim.wallet.service;
+
+import gorbiel.stock_sim.wallet.dto.WalletResponse;
+import gorbiel.stock_sim.wallet.dto.WalletStockResponse;
+import gorbiel.stock_sim.wallet.repository.WalletStockHoldingRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WalletQueryServiceImpl implements WalletQueryService {
+
+    private final WalletStockHoldingRepository walletStockHoldingRepository;
+
+    @Override
+    public WalletResponse getWallet(String walletId) {
+        List<WalletStockResponse> stocks = walletStockHoldingRepository.findAllByWalletId(walletId).stream()
+                .map(holding -> new WalletStockResponse(holding.getStockName(), holding.getQuantity()))
+                .toList();
+
+        return new WalletResponse(walletId, stocks);
+    }
+}


### PR DESCRIPTION
## Description

Implement `GET /wallets/{wallet_id}` endpoint.

The endpoint returns the current wallet state including:
- wallet id
- all stock holdings currently associated with the wallet
- stock names and quantities

## Changes

- Added response DTOs, query service, repository lookup, and controller endpoint.
- Moved all wallet endpoint to single controller class

## How to test
Steps to verify: `mvn clean test`

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)