### PR TITLE
feat: Add wallet single stock GET endpoint

### DIFF
--- a/src/main/java/gorbiel/stock_sim/wallet/controller/WalletController.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/controller/WalletController.java
@@ -29,4 +29,10 @@ public class WalletController {
     public ResponseEntity<WalletResponse> getWallet(@PathVariable String walletId) {
         return ResponseEntity.ok(walletQueryService.getWallet(walletId));
     }
+
+    @GetMapping("/wallets/{walletId}/stocks/{stockName}")
+    public ResponseEntity<Integer> getWalletStockQuantity(
+            @PathVariable String walletId, @PathVariable String stockName) {
+        return ResponseEntity.ok(walletQueryService.getWalletStockQuantity(walletId, stockName));
+    }
 }

--- a/src/main/java/gorbiel/stock_sim/wallet/service/WalletQueryService.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/service/WalletQueryService.java
@@ -5,4 +5,6 @@ import gorbiel.stock_sim.wallet.dto.WalletResponse;
 public interface WalletQueryService {
 
     WalletResponse getWallet(String walletId);
+
+    int getWalletStockQuantity(String walletId, String stockName);
 }

--- a/src/main/java/gorbiel/stock_sim/wallet/service/WalletQueryServiceImpl.java
+++ b/src/main/java/gorbiel/stock_sim/wallet/service/WalletQueryServiceImpl.java
@@ -2,6 +2,7 @@ package gorbiel.stock_sim.wallet.service;
 
 import gorbiel.stock_sim.wallet.dto.WalletResponse;
 import gorbiel.stock_sim.wallet.dto.WalletStockResponse;
+import gorbiel.stock_sim.wallet.model.WalletStockHolding;
 import gorbiel.stock_sim.wallet.repository.WalletStockHoldingRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,5 +21,13 @@ public class WalletQueryServiceImpl implements WalletQueryService {
                 .toList();
 
         return new WalletResponse(walletId, stocks);
+    }
+
+    @Override
+    public int getWalletStockQuantity(String walletId, String stockName) {
+        return walletStockHoldingRepository
+                .findByWalletIdAndStockName(walletId, stockName)
+                .map(WalletStockHolding::getQuantity)
+                .orElse(0);
     }
 }


### PR DESCRIPTION
## Description

Implement `GET /wallets/{wallet_id}/stocks/{stock_name}` endpoint.

The endpoint returns a single numeric value representing the quantity of the requested stock held by the wallet.

If the wallet or stock holding does not exist, the endpoint returns `0`.

## How to test
Steps to verify: `mvn clean test`

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)