### PR TITLE
feat: Add audit log GET endpoint

### DIFF
--- a/src/main/java/gorbiel/stock_sim/audit/controller/AuditLogController.java
+++ b/src/main/java/gorbiel/stock_sim/audit/controller/AuditLogController.java
@@ -1,0 +1,20 @@
+package gorbiel.stock_sim.audit.controller;
+
+import gorbiel.stock_sim.audit.dto.AuditLogResponse;
+import gorbiel.stock_sim.audit.service.AuditLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuditLogController {
+
+    private final AuditLogService auditLogService;
+
+    @GetMapping("/log")
+    public ResponseEntity<AuditLogResponse> getLog() {
+        return ResponseEntity.ok(auditLogService.getLog());
+    }
+}

--- a/src/main/java/gorbiel/stock_sim/audit/dto/AuditLogEntryResponse.java
+++ b/src/main/java/gorbiel/stock_sim/audit/dto/AuditLogEntryResponse.java
@@ -1,0 +1,7 @@
+package gorbiel.stock_sim.audit.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import gorbiel.stock_sim.audit.model.OperationType;
+
+public record AuditLogEntryResponse(
+        OperationType type, @JsonProperty("wallet_id") String walletId, @JsonProperty("stock_name") String stockName) {}

--- a/src/main/java/gorbiel/stock_sim/audit/dto/AuditLogResponse.java
+++ b/src/main/java/gorbiel/stock_sim/audit/dto/AuditLogResponse.java
@@ -1,0 +1,5 @@
+package gorbiel.stock_sim.audit.dto;
+
+import java.util.List;
+
+public record AuditLogResponse(List<AuditLogEntryResponse> log) {}

--- a/src/main/java/gorbiel/stock_sim/audit/service/AuditLogService.java
+++ b/src/main/java/gorbiel/stock_sim/audit/service/AuditLogService.java
@@ -1,0 +1,8 @@
+package gorbiel.stock_sim.audit.service;
+
+import gorbiel.stock_sim.audit.dto.AuditLogResponse;
+
+public interface AuditLogService {
+
+    AuditLogResponse getLog();
+}

--- a/src/main/java/gorbiel/stock_sim/audit/service/AuditLogServiceImpl.java
+++ b/src/main/java/gorbiel/stock_sim/audit/service/AuditLogServiceImpl.java
@@ -1,0 +1,21 @@
+package gorbiel.stock_sim.audit.service;
+
+import gorbiel.stock_sim.audit.dto.AuditLogEntryResponse;
+import gorbiel.stock_sim.audit.dto.AuditLogResponse;
+import gorbiel.stock_sim.audit.repository.AuditLogEntryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuditLogServiceImpl implements AuditLogService {
+
+    private final AuditLogEntryRepository auditLogEntryRepository;
+
+    @Override
+    public AuditLogResponse getLog() {
+        return new AuditLogResponse(auditLogEntryRepository.findAllByOrderByIdAsc().stream()
+                .map(entry -> new AuditLogEntryResponse(entry.getType(), entry.getWalletId(), entry.getStockName()))
+                .toList());
+    }
+}


### PR DESCRIPTION
## Description

Implement `GET /log` endpoint.

The endpoint returns successful wallet operations in insertion order using the expected response contract:
- operation type
- wallet ID
- stock name

Audit log entries are retrieved in database identifier order to preserve occurrence order.

## How to test
Steps to verify: `mvn clean test`

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)