### PR TITLE
feat: update GlobalExceptionHandler to map all defined exceptions and…

### DIFF
--- a/src/main/java/gorbiel/stock_sim/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/gorbiel/stock_sim/exception/handler/GlobalExceptionHandler.java
@@ -7,6 +7,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.time.Instant;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
 @RestControllerAdvice
@@ -19,6 +21,30 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<ApiErrorResponse> handleBadRequest(BadRequestException ex, HttpServletRequest request) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleValidationError(
+            MethodArgumentNotValidException ex, HttpServletRequest request) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(error -> "%s %s".formatted(error.getField(), error.getDefaultMessage()))
+                .orElse("Validation failed");
+
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, message, request);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiErrorResponse> handleInvalidRequestBody(
+            HttpMessageNotReadableException ex, HttpServletRequest request) {
+        return buildErrorResponse(
+                HttpStatus.BAD_REQUEST, ex.getMostSpecificCause().getMessage(), request);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiErrorResponse> handleIllegalArgument(
+            IllegalArgumentException ex, HttpServletRequest request) {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
     }
 


### PR DESCRIPTION
… use consistent response format

## Description

Implement centralized API exception handling.



## Changes

- The global exception handler now maps expected application errors to consistent JSON responses:
  - unknown stock names -> `404 Not Found`
  - insufficient bank stock -> `400 Bad Request`
  - insufficient wallet stock -> `400 Bad Request`
  - validation errors -> `400 Bad Request`
  - malformed request bodies -> `400 Bad Request`
  - invalid operation values -> `400 Bad Request`
- All handled errors use the shared `ApiErrorResponse` format.

## How to test
Steps to verify: `mvn clean test`

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)