### PR TITLE
fix: use NotEmpty instead of NotNull in UpdateBankStocksRequest

### DIFF
--- a/src/main/java/gorbiel/stock_sim/bank/dto/UpdateBankStocksRequest.java
+++ b/src/main/java/gorbiel/stock_sim/bank/dto/UpdateBankStocksRequest.java
@@ -1,7 +1,7 @@
 package gorbiel.stock_sim.bank.dto;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
-public record UpdateBankStocksRequest(@NotNull List<@Valid BankStockItemRequest> stocks) {}
+public record UpdateBankStocksRequest(@NotEmpty List<@Valid BankStockItemRequest> stocks) {}


### PR DESCRIPTION
## Description

Add request validation for API payloads.

Covered:
- required wallet operation type
- allowed wallet operation values through enum parsing
- required bank stock list
- non-empty bank stock list
- required stock names
- non-negative stock quantities

Invalid requests are handled through the global exception handler and return `400 Bad Request`.

## How to test
Steps to verify: `mvn clean test`

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)