### PR TITLE
feat: add POST /chaos endpoint for testing availability

### DIFF
--- a/src/main/java/gorbiel/stock_sim/availability/controller/ChaosController.java
+++ b/src/main/java/gorbiel/stock_sim/availability/controller/ChaosController.java
@@ -1,0 +1,18 @@
+package gorbiel.stock_sim.availability.controller;
+
+import gorbiel.stock_sim.availability.service.ChaosService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ChaosController {
+
+    private final ChaosService chaosService;
+
+    @PostMapping("/chaos")
+    public void chaos() {
+        chaosService.terminate();
+    }
+}

--- a/src/main/java/gorbiel/stock_sim/availability/service/ChaosService.java
+++ b/src/main/java/gorbiel/stock_sim/availability/service/ChaosService.java
@@ -1,0 +1,6 @@
+package gorbiel.stock_sim.availability.service;
+
+public interface ChaosService {
+
+    void terminate();
+}

--- a/src/main/java/gorbiel/stock_sim/availability/service/ChaosServiceImpl.java
+++ b/src/main/java/gorbiel/stock_sim/availability/service/ChaosServiceImpl.java
@@ -1,0 +1,21 @@
+package gorbiel.stock_sim.availability.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChaosServiceImpl implements ChaosService {
+
+    @Override
+    public void terminate() {
+        new Thread(() -> {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+
+                    System.exit(1);
+                })
+                .start();
+    }
+}


### PR DESCRIPTION
## Description

Implement `POST /chaos` endpoint.

The endpoint delegates to a service that terminates the current application instance after a short delay, allowing the request to begin processing before shutdown.

The implementation follows standard controller-service structure for consistency with the rest of the application.

## How to test
Steps to verify: `mvn clean test`

## Checklist
- [x] Code builds (`mvn clean install`)
- [x] Tests pass
- [x] No debug logs / TODOs left
- [ ] API documented (if applicable)

## Screenshots / Logs (if applicable)